### PR TITLE
[PLAT-3015] Message: extend admin api 'DELETE /acme_domain/:host/' to also delete respective certificates

### DIFF
--- a/kong-plugin-acme-0.2.10-3.rockspec
+++ b/kong-plugin-acme-0.2.10-3.rockspec
@@ -1,5 +1,5 @@
 package = "kong-plugin-acme"
-version = "0.2.10-2"
+version = "0.2.10-3"
 source = {
    url = "git+https://github.com/Kong/kong-plugin-acme.git",
    tag = "0.2.10",

--- a/kong/plugins/acme/api.lua
+++ b/kong/plugins/acme/api.lua
@@ -100,8 +100,8 @@ return {
         return kong.response.exit(500, { message = "failed to retrieve sni entry for host: " .. host .. " : " .. err })
       end
       if not sni_entity then
-        kong.log.info("Could not find sni_entity for: " .. host .. " ..continuing for certificate record deletion")
-        return kong.response.exit(400, { message = "could not find sni_entity to delete corresponding certificate record"})
+        kong.log.info("Could not find sni_entity for: " .. host)
+        return kong.response.exit(204, {})
       end
       local cert_id = sni_entity.certificate.id
       -- delete certificate for the sni_entity and sni_entity record

--- a/kong/plugins/acme/handler.lua
+++ b/kong/plugins/acme/handler.lua
@@ -131,7 +131,7 @@ end
 function LetsencryptHandler:init_worker()
   local worker_id = ngx.worker.id()
   kong.log.info("acme renew timer started on worker ", worker_id)
-  ngx.timer.every(86400, client.renew_certificate)
+  ngx.timer.every(120, client.renew_certificate)
 end
 
 function LetsencryptHandler:certificate(conf)

--- a/kong/plugins/acme/handler.lua
+++ b/kong/plugins/acme/handler.lua
@@ -131,7 +131,7 @@ end
 function LetsencryptHandler:init_worker()
   local worker_id = ngx.worker.id()
   kong.log.info("acme renew timer started on worker ", worker_id)
-  ngx.timer.every(120, client.renew_certificate)
+  ngx.timer.every(86400, client.renew_certificate)
 end
 
 function LetsencryptHandler:certificate(conf)


### PR DESCRIPTION
Description:
* Delete the acme_domain first, then delete the snis and certiicates records related to it
* If there is no acme_domain record for given host, try to delete the sni and certificates records also.
* If there is no sni record, then certficates deletion is not attempted (certificate id is required, which is taken from snis table)
* The above functionality is added to the DELETE /acme_domain/:host (an admin api)

Reference(s):
* JIRA -> https://instamojo.atlassian.net/browse/PLAT-3015