### PR TITLE
[PLAT-3061] Message: Renew Worker Lock with 1 Hr TTL (if not deleted)

### DIFF
--- a/kong-plugin-acme-0.2.10-7.rockspec
+++ b/kong-plugin-acme-0.2.10-7.rockspec
@@ -1,5 +1,5 @@
 package = "kong-plugin-acme"
-version = "0.2.10-6"
+version = "0.2.10-7"
 source = {
    url = "git+https://github.com/Kong/kong-plugin-acme.git",
    tag = "0.2.10",

--- a/kong/plugins/acme/client.lua
+++ b/kong/plugins/acme/client.lua
@@ -137,15 +137,7 @@ local function store_worker_config(conf)
   if err then
     return err
   end
-  return st:set(WORKER_KEY, tostring(ngx.worker.id()), 3600) -- 1 Hour TTL
-end
-
-local function get_worker_config(conf)
-  local _, st, err = new_storage_adapter(conf)
-  if err then
-    return nil, err
-  end
-  return st:get(WORKER_KEY)
+  return st:add(WORKER_KEY, tostring(ngx.worker.id()), 3600) -- 1 Hour TTL
 end
 
 local function delete_worker_config(conf)
@@ -550,17 +542,13 @@ local function renew_certificate(premature)
     if plugin.name == "acme" then
       kong.log.info("renew storage configured in acme plugin: ", plugin.id)
 
-      -- If Renew Worker Key Not Exists
-      local worker, _ = get_worker_config(plugin.config)
-      if worker then
-        kong.log.notice("Worker lock exists in acme storage. Another worker '" .. worker .. "' seems to be renewing. Skipping renewal flow for worker " .. ngx.worker.id())
-        return
-      end
-      --  Create & Save Worker Key
+      -- Create & Save Worker Key
+      -- If worker key already exists, then this means some other worker is renew_config
+      -- Else, continue?
       local err = store_worker_config(plugin.config)
-      if err then
+      if err and err == "exists" then
         kong.log.err("Could not place worker lock: " .. ngx.worker.id() .. " with error: " .. err)
-        -- continue?
+        return
       end
 
       local x = ngx.time()
@@ -570,7 +558,7 @@ local function renew_certificate(premature)
       --- Delete Renewal Worker Lock
       local err_del = delete_worker_config(plugin.config)
       if err_del then
-        kong.log.err("failed to delete worker_key lock for " .. worker .. " with error:" .. err_del)
+        kong.log.err("failed to delete worker_key lock for " .. ngx.worker.id() .. " with error:" .. err_del)
       end
     end
   end

--- a/kong/plugins/acme/client.lua
+++ b/kong/plugins/acme/client.lua
@@ -10,6 +10,7 @@ local dbless = kong.configuration.database == "off"
 local RENEW_KEY_PREFIX = "kong_acme:renew_config:"
 local RENEW_LAST_RUN_KEY = "kong_acme:renew_last_run"
 local CERTKEY_KEY_PREFIX = "kong_acme:cert_key:"
+local WORKER_KEY = "kong_acme:renew_worker"
 
 local LOCK_TIMEOUT = 30 -- in seconds
 
@@ -129,6 +130,30 @@ local function new_storage_adapter(conf)
   local lib = require(storage)
   local st, err = lib.new(storage_config)
   return storage, st, err
+end
+
+local function store_worker_config(conf)
+  local _, st, err = new_storage_adapter(conf)
+  if err then
+    return err
+  end
+  return st:set(WORKER_KEY, tostring(ngx.worker.id()), 3600) -- 1 Hour TTL
+end
+
+local function get_worker_config(conf)
+  local _, st, err = new_storage_adapter(conf)
+  if err then
+    return nil, err
+  end
+  return st:get(WORKER_KEY)
+end
+
+local function delete_worker_config(conf)
+  local _, st, err = new_storage_adapter(conf)
+  if err then
+    return nil, err
+  end
+  return st:delete(WORKER_KEY)
 end
 
 -- Return error (else  nil)
@@ -524,9 +549,29 @@ local function renew_certificate(premature)
 
     if plugin.name == "acme" then
       kong.log.info("renew storage configured in acme plugin: ", plugin.id)
+
+      -- If Renew Worker Key Not Exists
+      local worker, _ = get_worker_config(plugin.config)
+      if worker then
+        kong.log.notice("Worker lock exists in acme storage. Another worker '" .. worker .. "' seems to be renewing. Skipping renewal flow for worker " .. ngx.worker.id())
+        return
+      end
+      --  Create & Save Worker Key
+      local err = store_worker_config(plugin.config)
+      if err then
+        kong.log.err("Could not place worker lock: " .. ngx.worker.id() .. " with error: " .. err)
+        -- continue?
+      end
+
       local x = ngx.time()
       renew_certificate_storage(plugin.config)
       kong.log.info("Time take for renewal flow by worker " .. ngx.worker.id() .. " is " ..  ngx.time()-x)
+
+      --- Delete Renewal Worker Lock
+      local err_del = delete_worker_config(plugin.config)
+      if err_del then
+        kong.log.err("failed to delete worker_key lock for " .. worker .. " with error:" .. err_del)
+      end
     end
   end
 end

--- a/kong/plugins/acme/client.lua
+++ b/kong/plugins/acme/client.lua
@@ -560,8 +560,9 @@ local function renew_certificate(premature)
       local err_del = delete_worker_config(plugin.config)
       if err_del then
         kong.log.err("failed to delete worker_key lock for " .. ngx.worker.id() .. " with error:" .. err_del)
+      else
+        kong.log.info("Successfully removed worker lock: " .. ngx.worker.id())
       end
-      kong.log.info("Successfully removed worker lock: " .. ngx.worker.id())
     end
   end
 end

--- a/kong/plugins/acme/client.lua
+++ b/kong/plugins/acme/client.lua
@@ -546,10 +546,11 @@ local function renew_certificate(premature)
       -- If worker key already exists, then this means some other worker is renew_config
       -- Else, continue?
       local err = store_worker_config(plugin.config)
-      if err and err == "exists" then
+      if err then
         kong.log.err("Could not place worker lock: " .. ngx.worker.id() .. " with error: " .. err)
         return
       end
+      kong.log.info("Successfully placed worker lock: " .. ngx.worker.id())
 
       local x = ngx.time()
       renew_certificate_storage(plugin.config)
@@ -560,6 +561,7 @@ local function renew_certificate(premature)
       if err_del then
         kong.log.err("failed to delete worker_key lock for " .. ngx.worker.id() .. " with error:" .. err_del)
       end
+      kong.log.info("Successfully removed worker lock: " .. ngx.worker.id())
     end
   end
 end


### PR DESCRIPTION
Description:
* Prevent multiple workers from starting renewal flow while the first one is running
* Worker Lock will be deleted after the renewal is completed
* If not deleted, it will be automatically deleted after TTL (1 Hr). [[Reference](https://github.com/Kong/kong-plugin-acme/blob/f236fac0abdd76c952eb6cd34c8780d36d25074b/spec/02-kong_storage_spec.lua#L88)]
* implemented dao add() (instead of set()) as it returns error if config object already exists in db

References(s):
* JIRA -> https://instamojo.atlassian.net/browse/PLAT-3061
* DAO -> https://github.com/Kong/kong-plugin-acme/blob/f236fac0abdd76c952eb6cd34c8780d36d25074b/kong/plugins/acme/storage/kong.lua#L16